### PR TITLE
読者ユーザのパスワード管理まわりを実装（再設定、リセット）

### DIFF
--- a/django/accounts/forms.py
+++ b/django/accounts/forms.py
@@ -1,9 +1,28 @@
+from django import forms
+from django.contrib.auth import get_user_model
 from django.contrib.auth.forms import (
     AuthenticationForm,
     PasswordChangeForm,
     PasswordResetForm,
     SetPasswordForm,
+    UserCreationForm,
 )
+from django.utils.translation import ugettext_lazy as _
+
+User = get_user_model()
+
+
+class MyRegisterForm(UserCreationForm):
+    email = forms.EmailField(label=_("Email"), required=True)
+
+    class Meta:
+        model = User
+        fields = ('username', 'email', 'password1', 'password2')
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for field in self.fields.values():
+            field.widget.attrs['class'] = 'form-control'
 
 
 class MyLoginForm(AuthenticationForm):

--- a/django/accounts/forms.py
+++ b/django/accounts/forms.py
@@ -1,8 +1,17 @@
 from django.contrib.auth.forms import (
+    AuthenticationForm,
     PasswordChangeForm,
     PasswordResetForm,
     SetPasswordForm,
 )
+
+
+class MyLoginForm(AuthenticationForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for field in self.fields.values():
+            field.widget.attrs['class'] = 'form-control'
+            field.widget.attrs['placeholder'] = field.label
 
 
 class MyPasswordChangeForm(PasswordChangeForm):

--- a/django/accounts/forms.py
+++ b/django/accounts/forms.py
@@ -1,9 +1,17 @@
 from django.contrib.auth.forms import (
     PasswordChangeForm,
+    PasswordResetForm,
 )
 
 
 class MyPasswordChangeForm(PasswordChangeForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for field in self.fields.values():
+            field.widget.attrs['class'] = 'form-control'
+
+
+class MyPasswordResetForm(PasswordResetForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         for field in self.fields.values():

--- a/django/accounts/forms.py
+++ b/django/accounts/forms.py
@@ -1,6 +1,7 @@
 from django.contrib.auth.forms import (
     PasswordChangeForm,
     PasswordResetForm,
+    SetPasswordForm,
 )
 
 
@@ -12,6 +13,13 @@ class MyPasswordChangeForm(PasswordChangeForm):
 
 
 class MyPasswordResetForm(PasswordResetForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for field in self.fields.values():
+            field.widget.attrs['class'] = 'form-control'
+
+
+class MySetPasswordForm(SetPasswordForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         for field in self.fields.values():

--- a/django/accounts/forms.py
+++ b/django/accounts/forms.py
@@ -1,0 +1,10 @@
+from django.contrib.auth.forms import (
+    PasswordChangeForm,
+)
+
+
+class MyPasswordChangeForm(PasswordChangeForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for field in self.fields.values():
+            field.widget.attrs['class'] = 'form-control'

--- a/django/accounts/templates/accounts/login.html
+++ b/django/accounts/templates/accounts/login.html
@@ -21,4 +21,9 @@
     <input type="submit" value="login">
     <input type="hidden" name="next" value="{{ next }}">
   </form>
+  <p>
+    <a href="{% url 'accounts:password_reset' %}">
+      パスワードをお忘れの場合
+    </a>
+  </p>
 {% endblock %}

--- a/django/accounts/templates/accounts/login.html
+++ b/django/accounts/templates/accounts/login.html
@@ -7,18 +7,14 @@
 
   <form method="POST" action="{% url 'accounts:login' %}">
     {% csrf_token %}
-    <table>
-      <tr>
-        <td>{{ form.username.label_tag }}</td>
-        <td>{{ form.username }}</td>
-      </tr>
-      <tr>
-        <td>{{ form.password.label_tag }}</td>
-        <td>{{ form.password }}</td>
-      </tr>
-    </table>
+    {% for field in form %}
+      <div class="form-group">
+        {{ field }}
+        {{ field.errors }}
+      </div>
+    {% endfor %}
 
-    <input type="submit" value="login">
+    <input type="submit" class="btn btn-primary btn-lg" value="login">
     <input type="hidden" name="next" value="{{ next }}">
   </form>
   <p>

--- a/django/accounts/templates/accounts/mail_template/password_reset/message.html
+++ b/django/accounts/templates/accounts/mail_template/password_reset/message.html
@@ -1,0 +1,7 @@
+{{ user.username }} 様
+
+下記URLよりサイトにアクセスの上、パスワードの再設定を行ってください。
+
+{{ protocol }}://{{ domain }}{% url 'accounts:password_reset_confirm' uidb64=uid token=token %}
+
+このメールに心当たりがない場合は操作せず無視してください。

--- a/django/accounts/templates/accounts/mail_template/password_reset/subject.txt
+++ b/django/accounts/templates/accounts/mail_template/password_reset/subject.txt
@@ -1,0 +1,1 @@
+Django Girls Blog 読者のパスワード再設定

--- a/django/accounts/templates/accounts/password_change.html
+++ b/django/accounts/templates/accounts/password_change.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+
+{% block content %}
+  <h2>Change Password</h2>
+  <form method="POST">
+    {% csrf_token %}
+    {{ form.non_field_errors }}
+    {% for field in form %}
+      <div class="form-group">
+        <label for="{{ field.id_for_label }}">{{ field.label_tag }}</label>
+        {{ field }}
+        {{ field.errors }}
+      </div>
+    {% endfor %}
+    <button type="submit" class="btn btn-primary">Change</button>
+  </form>
+{% endblock %}

--- a/django/accounts/templates/accounts/password_change_done.html
+++ b/django/accounts/templates/accounts/password_change_done.html
@@ -1,0 +1,7 @@
+{% extends 'base.html' %}
+
+{% block content %}
+  <p>
+    パスワードを変更しました。
+  </p>
+{% endblock %}

--- a/django/accounts/templates/accounts/password_reset_complete.html
+++ b/django/accounts/templates/accounts/password_reset_complete.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+
+{% block content %}
+  <p>
+    パスワードを再設定しました
+  </p>
+  <a class="btn btn-primary btn-lg"
+      href="{% url 'accounts:login' %}">
+    ログイン
+  </a>
+{% endblock %}

--- a/django/accounts/templates/accounts/password_reset_confirm.html
+++ b/django/accounts/templates/accounts/password_reset_confirm.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+
+{% block content %}
+  <h2>Change Password</h2>
+  <form method="POST">
+    {% csrf_token %}
+    {{ form.non_field_errors }}
+    {% for field in form %}
+      <div class="form-group">
+        <label for="{{ field.id_for_label }}">{{ field.label_tag }}</label>
+        {{ field }}
+        {{ field.errors }}
+      </div>
+    {% endfor %}
+    <button type="submit" class="btn btn-primary">Change</button>
+  </form>
+{% endblock %}

--- a/django/accounts/templates/accounts/password_reset_done.html
+++ b/django/accounts/templates/accounts/password_reset_done.html
@@ -1,0 +1,8 @@
+{% extends 'base.html' %}
+
+{% block content %}
+  <p>
+    パスワード再設定用のメールを送信しました。<br>
+    メールのリンクからパスワードを再設定してください
+  </p>
+{% endblock %}

--- a/django/accounts/templates/accounts/password_reset_form.html
+++ b/django/accounts/templates/accounts/password_reset_form.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+
+{% block content %}
+  <h2>Reset Password</h2>
+  <form method="POST">
+    {% csrf_token %}
+    {{ form.non_field_errors }}
+    {% for field in form %}
+      <div class="form-group">
+        <label for="{{ field.id_for_label }}">{{ field.label_tag }}</label>
+        {{ field }}
+        {{ field.errors }}
+      </div>
+    {% endfor %}
+    <button type="submit" class="btn btn-primary">Reset</button>
+  </form>
+{% endblock %}

--- a/django/accounts/templates/accounts/register.html
+++ b/django/accounts/templates/accounts/register.html
@@ -11,20 +11,14 @@
   {% endif %}
   <form method="POST">
     {% csrf_token %}
-    <table>
-      <tr>
-        <td>{{ form.username.label_tag }}</td>
-        <td>{{ form.username }}</td>
-      </tr>
-      <tr>
-        <td>{{ form.password1.label_tag }}</td>
-        <td>{{ form.password1 }}</td>
-      </tr>
-      <tr>
-        <td>{{ form.password2.label_tag }}</td>
-        <td>{{ form.password2 }}</td>
-      </tr>
-    </table>
+    {{ form.non_field_errors }}
+    {% for field in form %}
+      <div class="form-group">
+        <label for="{{ field.id_for_label }}">{{ field.label_tag }}</label>
+        {{ field }}
+        {{ field.errors }}
+      </div>
+    {% endfor %}
     <input type="submit" value="register">
   </form>
 {% endblock %}

--- a/django/accounts/urls.py
+++ b/django/accounts/urls.py
@@ -20,4 +20,8 @@ urlpatterns = [
          name='password_reset'),
     path('password_reset/done/', views.PasswordResetDone.as_view(),
          name='password_reset_done'),
+    path('password_reset/confirm/<uidb64>/<token>/',
+         views.PasswordResetConfirm.as_view(), name='password_reset_confirm'),
+    path('password_reset/complete/', views.PasswordResetComplete.as_view(),
+         name='password_reset_complete'),
 ]

--- a/django/accounts/urls.py
+++ b/django/accounts/urls.py
@@ -7,10 +7,8 @@ from . import views
 app_name = 'accounts'
 urlpatterns = [
     path('register/', views.RegisterView.as_view(), name='register'),
-    path('login/',
-         auth_views.LoginView.as_view(template_name='accounts/login.html'),
-         name='login'),
-    path('logout/', auth_views.LogoutView.as_view(next_page='/'),
+    path('login/', views.MyLoginView.as_view(), name='login'),
+    path('logout/', auth_views.LogoutView.as_view(next_page='blog:post_list'),
          name='logout'),
     path('password_change/', views.PasswordChange.as_view(),
          name='password_change'),

--- a/django/accounts/urls.py
+++ b/django/accounts/urls.py
@@ -16,4 +16,8 @@ urlpatterns = [
          name='password_change'),
     path('password_change/done/', views.PasswordChangeDone.as_view(),
          name='password_change_done'),
+    path('password_reset/', views.PasswordReset.as_view(),
+         name='password_reset'),
+    path('password_reset/done/', views.PasswordResetDone.as_view(),
+         name='password_reset_done'),
 ]

--- a/django/accounts/urls.py
+++ b/django/accounts/urls.py
@@ -12,4 +12,8 @@ urlpatterns = [
          name='login'),
     path('logout/', auth_views.LogoutView.as_view(next_page='/'),
          name='logout'),
+    path('password_change/', views.PasswordChange.as_view(),
+         name='password_change'),
+    path('password_change/done/', views.PasswordChangeDone.as_view(),
+         name='password_change_done'),
 ]

--- a/django/accounts/views.py
+++ b/django/accounts/views.py
@@ -4,6 +4,8 @@ from django.contrib.auth.models import Group
 from django.contrib.auth.views import (
     PasswordChangeView,
     PasswordChangeDoneView,
+    PasswordResetView,
+    PasswordResetDoneView,
 )
 from django.http import HttpResponseRedirect
 from django.urls import reverse_lazy
@@ -11,6 +13,7 @@ from django.views.generic import CreateView
 
 from accounts.forms import (
     MyPasswordChangeForm,
+    MyPasswordResetForm,
 )
 
 
@@ -39,3 +42,16 @@ class PasswordChange(PasswordChangeView):
 
 class PasswordChangeDone(PasswordChangeDoneView):
     template_name = 'accounts/password_change_done.html'
+
+
+class PasswordReset(PasswordResetView):
+    subject_template_name = 'accounts/mail_template/password_reset/subject.txt'
+    email_template_name = 'accounts/mail_template/password_reset/message.html'
+    template_name = 'accounts/password_reset_form.html'
+    form_class = MyPasswordResetForm
+    success_url = reverse_lazy('accounts:password_reset_done')
+
+
+class PasswordResetDone(PasswordResetDoneView):
+    """パスワード変更用URLをメール送付する"""
+    template_name = 'accounts/password_reset_done.html'

--- a/django/accounts/views.py
+++ b/django/accounts/views.py
@@ -1,9 +1,17 @@
 from django.contrib.auth import login
 from django.contrib.auth.forms import UserCreationForm
 from django.contrib.auth.models import Group
+from django.contrib.auth.views import (
+    PasswordChangeView,
+    PasswordChangeDoneView,
+)
 from django.http import HttpResponseRedirect
 from django.urls import reverse_lazy
 from django.views.generic import CreateView
+
+from accounts.forms import (
+    MyPasswordChangeForm,
+)
 
 
 class RegisterView(CreateView):
@@ -21,3 +29,13 @@ class RegisterView(CreateView):
         user.groups.add(group)
         login(self.request, user)
         return HttpResponseRedirect(self.success_url)
+
+
+class PasswordChange(PasswordChangeView):
+    form_class = MyPasswordChangeForm
+    success_url = reverse_lazy('accounts:password_change_done')
+    template_name = 'accounts/password_change.html'
+
+
+class PasswordChangeDone(PasswordChangeDoneView):
+    template_name = 'accounts/password_change_done.html'

--- a/django/accounts/views.py
+++ b/django/accounts/views.py
@@ -5,6 +5,8 @@ from django.contrib.auth.views import (
     PasswordChangeView,
     PasswordChangeDoneView,
     PasswordResetView,
+    PasswordResetConfirmView,
+    PasswordResetCompleteView,
     PasswordResetDoneView,
 )
 from django.http import HttpResponseRedirect
@@ -14,6 +16,7 @@ from django.views.generic import CreateView
 from accounts.forms import (
     MyPasswordChangeForm,
     MyPasswordResetForm,
+    MySetPasswordForm,
 )
 
 
@@ -55,3 +58,14 @@ class PasswordReset(PasswordResetView):
 class PasswordResetDone(PasswordResetDoneView):
     """パスワード変更用URLをメール送付する"""
     template_name = 'accounts/password_reset_done.html'
+
+
+class PasswordResetConfirm(PasswordResetConfirmView):
+    form_class = MySetPasswordForm
+    success_url = reverse_lazy('accounts:password_reset_complete')
+    template_name = 'accounts/password_reset_confirm.html'
+
+
+class PasswordResetComplete(PasswordResetCompleteView):
+    """新パスワード設定完了画面"""
+    template_name = 'accounts/password_reset_complete.html'

--- a/django/accounts/views.py
+++ b/django/accounts/views.py
@@ -1,5 +1,4 @@
 from django.contrib.auth import login
-from django.contrib.auth.forms import UserCreationForm
 from django.contrib.auth.models import Group
 from django.contrib.auth.views import (
     LoginView,
@@ -18,13 +17,14 @@ from accounts.forms import (
     MyLoginForm,
     MyPasswordChangeForm,
     MyPasswordResetForm,
+    MyRegisterForm,
     MySetPasswordForm,
 )
 
 
 class RegisterView(CreateView):
     template_name = 'accounts/register.html'
-    form_class = UserCreationForm
+    form_class = MyRegisterForm
     success_url = reverse_lazy('blog:post_list')
 
     def form_valid(self, form):

--- a/django/accounts/views.py
+++ b/django/accounts/views.py
@@ -2,6 +2,7 @@ from django.contrib.auth import login
 from django.contrib.auth.forms import UserCreationForm
 from django.contrib.auth.models import Group
 from django.contrib.auth.views import (
+    LoginView,
     PasswordChangeView,
     PasswordChangeDoneView,
     PasswordResetView,
@@ -14,6 +15,7 @@ from django.urls import reverse_lazy
 from django.views.generic import CreateView
 
 from accounts.forms import (
+    MyLoginForm,
     MyPasswordChangeForm,
     MyPasswordResetForm,
     MySetPasswordForm,
@@ -35,6 +37,11 @@ class RegisterView(CreateView):
         user.groups.add(group)
         login(self.request, user)
         return HttpResponseRedirect(self.success_url)
+
+
+class MyLoginView(LoginView):
+    form_class = MyLoginForm
+    template_name = 'accounts/login.html'
 
 
 class PasswordChange(PasswordChangeView):

--- a/django/mysite/settings/base.py
+++ b/django/mysite/settings/base.py
@@ -128,4 +128,4 @@ STATICFILES_DIRS = [
 
 # User login
 
-LOGIN_REDIRECT_URL = '/'
+LOGIN_REDIRECT_URL = 'blog:post_list'

--- a/django/mysite/settings/local.py
+++ b/django/mysite/settings/local.py
@@ -27,3 +27,8 @@ INTERNAL_IPS = '127.0.0.1'
 
 MEDIA_URL = '/upload/'
 MEDIA_ROOT = os.path.join(BASE_DIR, '../media_root')
+
+
+# Email dummy
+
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'

--- a/django/templates/base.html
+++ b/django/templates/base.html
@@ -39,6 +39,9 @@
           </li>
           {% if user.is_authenticated %}
             <li class="nav-item">
+              <a class="nav-link" href="{% url 'accounts:password_change' %}">パスワード変更</a>
+            </li>
+            <li class="nav-item">
               <a class="nav-link" href="{% url 'accounts:logout' %}">読者ログアウト</a>
             </li>
           {% else %}


### PR DESCRIPTION
ローカルに残っていた変更を一旦マージ。
PythonAnywhereデプロイ用ブランチを用意し、必要な設定があればそちらで行う